### PR TITLE
bridge: fix error handling for stale default gateways

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -627,9 +627,7 @@ func (d *driver) checkConflict(config *networkConfiguration) error {
 	return nil
 }
 
-func (d *driver) createNetwork(config *networkConfiguration) error {
-	var err error
-
+func (d *driver) createNetwork(config *networkConfiguration) (err error) {
 	defer osl.InitOSContext()()
 
 	networkList := d.getNetworks()

--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -611,7 +611,7 @@ func (d *driver) checkConflict(config *networkConfiguration) error {
 		nwConfig := nw.config
 		nw.Unlock()
 		if err := nwConfig.Conflicts(config); err != nil {
-			if config.DefaultBridge {
+			if nwConfig.DefaultBridge {
 				// We encountered and identified a stale default network
 				// We must delete it as libnetwork is the source of truth
 				// The default network being created must be the only one


### PR DESCRIPTION
backport of https://github.com/docker/libnetwork/pull/2259