### PR TITLE
Change default network address pool

### DIFF
--- a/ipamutils/utils.go
+++ b/ipamutils/utils.go
@@ -27,13 +27,9 @@ func InitNetworks() {
 
 func initBroadPredefinedNetworks() []*net.IPNet {
 	pl := make([]*net.IPNet, 0, 31)
-	mask := []byte{255, 255, 0, 0}
-	for i := 17; i < 32; i++ {
-		pl = append(pl, &net.IPNet{IP: []byte{172, byte(i), 0, 0}, Mask: mask})
-	}
-	mask20 := []byte{255, 255, 240, 0}
-	for i := 0; i < 16; i++ {
-		pl = append(pl, &net.IPNet{IP: []byte{192, 168, byte(i << 4), 0}, Mask: mask20})
+	mask := []byte{255, 255, 255, 0}
+	for i := 105; i < 136; i++ {
+		pl = append(pl, &net.IPNet{IP: []byte{10, 114, byte(i), 0}, Mask: mask})
 	}
 	return pl
 }


### PR DESCRIPTION
From docker's defaults 172.x.0.0/16 and 192.168.x.0/20
to 10.114.{105-135}.0/24

Change-type: patch
Signed-off-by: Robert Günzler <robertg@balena.io>